### PR TITLE
Use Go modules for coverage CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,10 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+      - plugin-ci/coverage:
+          filters:
+            tags:
+              only: /^v.*/
       - plugin-ci/build:
           filters:
             tags:

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ endif
 
 ## Creates a coverage report for the server code.
 .PHONY: coverage
-coverage: server/.depensure webapp/.npminstall
+coverage: webapp/.npminstall
 ifneq ($(HAS_SERVER),)
 	$(GO) test -race -coverprofile=server/coverage.txt ./server/...
 	$(GO) tool cover -html=server/coverage.txt

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,3 +1,2 @@
 coverage.txt
 vendor
-.depensure


### PR DESCRIPTION
Completely removes `server/.depensure` dependencies from Makefile

Complement of #5