### PR TITLE
[GH-28] When notification unmarshaling fails, log the notification.Message

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -157,8 +157,10 @@ func (p *Plugin) handleNotification(body io.Reader) {
 
 	var messageNotification SNSMessageNotification
 	if err := json.Unmarshal([]byte(notification.Message), &messageNotification); err != nil {
-		p.API.LogError("AWSSNS HandleNotification Decode Error on message notification", "err=", err.Error())
-		p.API.LogError("AWSSNS HandleNotification Decode Error", "notification.Message=", notification.Message)
+		p.API.LogError(
+			"AWSSNS HandleNotification Decode Error on message notification",
+			"err", err.Error(),
+			"message", notification.Message)
 		return
 	}
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -158,6 +158,7 @@ func (p *Plugin) handleNotification(body io.Reader) {
 	var messageNotification SNSMessageNotification
 	if err := json.Unmarshal([]byte(notification.Message), &messageNotification); err != nil {
 		p.API.LogDebug("AWSSNS HandleNotification Decode Error on message notification", "err=", err.Error())
+		p.API.LogError("AWSSNS HandleNotification Decode Error", "notification.Message=", notification.Message)
 		return
 	}
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -157,7 +157,7 @@ func (p *Plugin) handleNotification(body io.Reader) {
 
 	var messageNotification SNSMessageNotification
 	if err := json.Unmarshal([]byte(notification.Message), &messageNotification); err != nil {
-		p.API.LogDebug("AWSSNS HandleNotification Decode Error on message notification", "err=", err.Error())
+		p.API.LogError("AWSSNS HandleNotification Decode Error on message notification", "err=", err.Error())
 		p.API.LogError("AWSSNS HandleNotification Decode Error", "notification.Message=", notification.Message)
 		return
 	}


### PR DESCRIPTION
#### Summary
Multiple users are noticing a use case where an SNS notification is sent, and responds with 200, but fails to unmarshal in the Mattermost AWS-SNS plugin.

A detailed response is provided, but the best scenario is to update the plugin to provide the `notification.Message` when the unmarshaling error occurs.  We need this payload to catch the type of notification sent and detect the cause of the issue.

Response in Issue:
https://github.com/mattermost/mattermost-plugin-aws-SNS/issues/28#issuecomment-597436071

#### Ticket Link
https://github.com/mattermost/mattermost-plugin-aws-SNS/issues/28
https://github.com/mattermost/mattermost-plugin-aws-SNS/issues/25