### PR TITLE
Add error message to the ephemeral post and log 

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -292,7 +292,8 @@ func (p *Plugin) handleAction(w http.ResponseWriter, r *http.Request) {
 	var action *Action
 	err := json.NewDecoder(r.Body).Decode(&action)
 	if err != nil || action == nil {
-		encodeEphermalMessage(w, "SNS BOT Error: We could not decode the action")
+		encodeEphermalMessage(w, fmt.Sprintf("SNS BOT Error: We could not decode the action. Error=%s", err.Error()))
+		p.API.LogError("SNS BOT Error: We could not decode the action.", "err=", err.Error())
 		return
 	}
 


### PR DESCRIPTION
#### Summary
When an error occurs during action decoding, the message was too generic. Change the error handling to both inform the user with an ephemeral post and logging for easier debug when this occurs.

#### Ticket Link
https://github.com/mattermost/mattermost-plugin-aws-SNS/issues/25