### PR TITLE
Fix panic if slash command args are empty

### DIFF
--- a/server/command.go
+++ b/server/command.go
@@ -32,7 +32,11 @@ func (p *Plugin) registerCommands() error {
 func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
 	splitCmd := strings.Fields(args.Command)
 	cmd := strings.TrimPrefix(splitCmd[0], "/")
-	action := splitCmd[1]
+
+	action := ""
+	if len(splitCmd) > 1 {
+		action = splitCmd[1]
+	}
 
 	if cmd != awsSNSCmd {
 		return &model.CommandResponse{


### PR DESCRIPTION
#### Summary
Given that only one command is supported I opted for a quick solution. The proper way would be to return a help text in that case. But I don't think it's worth for this simple command. 


#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-aws-SNS/issues/51

