### PR TITLE
Don't start plugin if siteURL is not set

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -33,8 +33,12 @@ type Plugin struct {
 const topicsListPrefix = "topicsInChannel_"
 
 func (p *Plugin) OnActivate() error {
-	configuration := p.getConfiguration()
+	siteURL := p.API.GetConfig().ServiceSettings.SiteURL
+	if siteURL == nil || *siteURL == "" {
+		return errors.New("siteURL is not set. Please set a siteURL and restart the plugin")
+	}
 
+	configuration := p.getConfiguration()
 	if err := p.IsValid(configuration); err != nil {
 		return err
 	}


### PR DESCRIPTION
#### Summary
That way the getting the siteURL won't panic

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-aws-SNS/issues/55