### PR TITLE
Replaced legacy GitBook URLs with PL link

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
     "id": "com.mattermost.aws-sns",
     "name": "AWS SNS",
     "description": "Send alert notifications from Amazon AWS CloudWatch to Mattermost channels via AWS SNS.",
-    "homepage_url": "https://github.com/mattermost/mattermost-plugin-aws-SNS",
+    "homepage_url": "https://mattermost.com/pl/mattermost-plugin-aws-SNS",
     "support_url": "https://github.com/mattermost/mattermost-plugin-aws-SNS/issues",
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-aws-SNS/releases/tag/v1.2.0",
     "icon_path": "assets/icon.svg",


### PR DESCRIPTION
Replaced absolute GitHub links with permalink [via Marketing](https://docs.google.com/spreadsheets/d/1O601H_A0IM8pR3FOfue29_C8flGV7xK3ts-tJUVDHHg/edit#gid=0).

Addresses: https://mattermost.atlassian.net/browse/MM-55436