### PR TITLE
feat: Perform changes related to CI/CD. Prepare plugin for community migration.

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,18 +1,10 @@
 name: cd
 on:
-  workflow_run:
-    workflows: ["ci"]
-    branches-ignore: ["*"]
-    types:
-      - completed
   push:
     tags:
       - "v*"
 
-permissions:
-  contents: read
-
 jobs:
   plugin-cd:
-    uses: mattermost/actions-workflows/.github/workflows/plugin-cd.yml@main
+    uses: mattermost/actions-workflows/.github/workflows/community-plugin-cd.yml@main
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,12 @@
 name: ci
 on:
-  schedule:
-    - cron: "0 0 * * *"
+  pull_request:
   push:
     branches:
       - master
-    tags:
-      - "v*"
-  pull_request:
-
-permissions:
-  contents: read
+      - main
 
 jobs:
   plugin-ci:
-    uses: mattermost/actions-workflows/.github/workflows/plugin-ci.yml@main
+    uses: mattermost/actions-workflows/.github/workflows/community-plugin-ci.yml@main
     secrets: inherit


### PR DESCRIPTION
#### Summary

- Remove scheduled ci workflow and upgrade plugin-ci reusable workflow
- Do not execute ci tasks upon tag creation
- Remove cd trigger upon workflow run event. Keep it simple upon tag creation. 

#### Related PRs
https://github.com/mattermost/actions/pull/22
https://github.com/mattermost/actions-workflows/pull/40

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-7458